### PR TITLE
🔒 [security fix] Remove unused xml.etree.ElementTree import in ixbrl.py

### DIFF
--- a/python/ixbrl.py
+++ b/python/ixbrl.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
-import xml.etree.ElementTree as ET
 import os
+import json
 
 output_dir = "output"
 os.makedirs(output_dir, exist_ok=True)
@@ -38,7 +38,6 @@ for filename in os.listdir("inlineXBRL"):
         #     print(r)
 
         # Write to JSON
-        import json
 
         # Sanitize title for filename
         sanitized_title = "".join([c for c in title if c.isalnum() or c in (' ', '.', '_')]).strip()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the presence of an unused and potentially insecure `xml.etree.ElementTree` import in `python/ixbrl.py`. Additionally, the `json` import was moved to the top of the file.

⚠️ **Risk:** While currently unused, `xml.etree.ElementTree` is vulnerable to XML External Entity (XXE) and other XML attacks when parsing untrusted data. Keeping it in the codebase increases the risk of accidental usage in the future, which could lead to data disclosure or server-side request forgery.

🛡️ **Solution:** Removed the insecure import completely. Improved the code structure by placing the `json` import at the top of the file, following standard Python practices and reducing unnecessary overhead inside the main processing loop. Verified the changes with syntax checks and import integrity tests.

---
*PR created automatically by Jules for task [4112673794775694411](https://jules.google.com/task/4112673794775694411) started by @nichsedge*