### PR TITLE
🧪 [testing improvement] Add FileNotFoundError test for Neo4j ingestion

### DIFF
--- a/python/tests/test_neo4j_ingest.py
+++ b/python/tests/test_neo4j_ingest.py
@@ -1,0 +1,45 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock dependencies that are not installed in the environment
+# This allows us to test the logic in neo4j_ingest.py without having to install all dependencies
+sys.modules["pandas"] = MagicMock()
+sys.modules["neo4j"] = MagicMock()
+sys.modules["dotenv"] = MagicMock()
+
+import unittest
+from io import StringIO
+from unittest.mock import patch
+import neo4j_ingest
+
+class TestNeo4jIngest(unittest.TestCase):
+    def test_ingest_all_stock_profiles_file_not_found(self):
+        """Test that ingest_all_stock_profiles handles FileNotFoundError gracefully."""
+        # Using a path that definitely doesn't exist
+        dummy_path = "non_existent_file_12345.json"
+
+        # Capture stdout to verify the error message
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            # The function should catch FileNotFoundError and return None
+            result = neo4j_ingest.ingest_all_stock_profiles(data_path=dummy_path)
+
+            output = fake_out.getvalue().strip()
+            self.assertIn(f"Error: Data file not found at {dummy_path}", output)
+            self.assertIsNone(result)
+
+    def test_ingest_all_stock_summaries_file_not_found(self):
+        """Test that ingest_all_stock_summaries handles FileNotFoundError gracefully."""
+        # Using a path that definitely doesn't exist
+        dummy_path = "non_existent_file_12345.json"
+
+        # Capture stdout to verify the error message
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            # The function should catch FileNotFoundError and return None
+            result = neo4j_ingest.ingest_all_stock_summaries(data_path=dummy_path)
+
+            output = fake_out.getvalue().strip()
+            self.assertIn(f"Error: Data file not found at {dummy_path}", output)
+            self.assertIsNone(result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* 🎯 **What:** Added unit tests to address the testing gap for `FileNotFoundError` handling in `ingest_all_stock_profiles` and `ingest_all_stock_summaries` within `python/neo4j_ingest.py`.
* 📊 **Coverage:** The new tests cover the scenario where the input JSON data file is missing, verifying that the functions catch the exception, print an informative error message, and return gracefully.
* ✨ **Result:** Increased code reliability and established a testing pattern in `python/tests/` using mocks for external dependencies (pandas, neo4j, dotenv) to allow testing in restricted environments.

---
*PR created automatically by Jules for task [9547144950141849467](https://jules.google.com/task/9547144950141849467) started by @nichsedge*