### PR TITLE
🔒 [security] Remove default passwords in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker compose up -d
 Neo4j will be available at:
 - Web UI: http://localhost:7474
 - Bolt: bolt://localhost:7687
-- Default Login: `neo4j` / `password`
+- Note: Credentials must be set in your `.env` file (see `.env.example`).
 
 ### 4. Running Scrapers
 The `python/` directory contains various scripts for data collection:

--- a/docker-compose/metabase.yml
+++ b/docker-compose/metabase.yml
@@ -9,7 +9,7 @@ services:
       MB_DB_DBNAME: postgres
       MB_DB_PORT: 5432
       MB_DB_USER: postgres
-      MB_DB_PASS: postgres
+      MB_DB_PASS: ${POSTGRES_PASSWORD}
       MB_DB_HOST: postgres
     depends_on:
       - postgres

--- a/docker-compose/neo4j.yml
+++ b/docker-compose/neo4j.yml
@@ -7,7 +7,7 @@ services:
       - ./neo4j_data/data:/data
       - ./neo4j_data/plugins:/plugins
     environment:
-        - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-password}
+        - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD}
     ports:
       - "7474:7474"
       - "7687:7687"

--- a/docker-compose/postgres.yml
+++ b/docker-compose/postgres.yml
@@ -4,7 +4,7 @@ services:
     container_name: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
     ports:
       - "5432:5432"

--- a/python/financial_ratios_json2pg.py
+++ b/python/financial_ratios_json2pg.py
@@ -27,7 +27,7 @@ PG_CONFIG = {
     'port': int(os.getenv('POSTGRES_PORT', 5432)),
     'database': os.getenv('POSTGRES_DB', 'postgres'),
     'user': os.getenv('POSTGRES_USER', 'postgres'),
-    'password': os.getenv('POSTGRES_PASSWORD', 'postgres')
+    'password': os.getenv('POSTGRES_PASSWORD')
 }
 
 # Database and table name

--- a/python/neo4j.ipynb
+++ b/python/neo4j.ipynb
@@ -26,7 +26,7 @@
     "# Neo4j connection config\n",
     "NEO4J_URI = os.getenv(\"NEO4J_URI\", \"neo4j://localhost:7687\")\n",
     "NEO4J_USER = os.getenv(\"NEO4J_USER\", \"neo4j\")\n",
-    "NEO4J_PASSWORD = os.getenv(\"NEO4J_PASSWORD\", \"password\")"
+    "NEO4J_PASSWORD = os.getenv(\"NEO4J_PASSWORD\")"
    ]
   },
   {
@@ -388,7 +388,7 @@
     "db_params = {\n",
     "    \"dbname\": os.getenv(\"POSTGRES_DB\", \"postgres\"),\n",
     "    \"user\": os.getenv(\"POSTGRES_USER\", \"postgres\"),\n",
-    "    \"password\": os.getenv(\"POSTGRES_PASSWORD\", \"postgres\"),\n",
+    "    \"password\": os.getenv(\"POSTGRES_PASSWORD\"),\n",
     "    \"host\": os.getenv(\"POSTGRES_HOST\", \"localhost\"),\n",
     "    \"port\": os.getenv(\"POSTGRES_PORT\", \"5432\")\n",
     "}\n",

--- a/python/neo4j_ingest.py
+++ b/python/neo4j_ingest.py
@@ -10,7 +10,7 @@ load_dotenv()  # Load environment variables from .env
 # Neo4j connection config
 NEO4J_URI = os.getenv("NEO4J_URI", "neo4j://localhost:7687")
 NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "password")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
 
 def clean_indonesian_name(name):
     """

--- a/python/stock_analysis_psql.py
+++ b/python/stock_analysis_psql.py
@@ -9,7 +9,7 @@ load_dotenv()  # Load environment variables from .env
 DB_PARAMS = {
     "dbname": os.getenv("POSTGRES_DB", "postgres"),
     "user": os.getenv("POSTGRES_USER", "postgres"),
-    "password": os.getenv("POSTGRES_PASSWORD", "postgres"),
+    "password": os.getenv("POSTGRES_PASSWORD"),
     "host": os.getenv("POSTGRES_HOST", "localhost"),
     "port": os.getenv("POSTGRES_PORT", "5432")
 }


### PR DESCRIPTION
🎯 **What:** Removed all hardcoded default passwords used as fallbacks in environment variable lookups and container configurations.

⚠️ **Risk:** Using hardcoded default credentials (like "password" or "postgres") poses a significant security risk, as it allows unauthorized access to databases and services if users do not explicitly override them.

🛡️ **Solution:** 
- Removed the default string from `os.getenv("NEO4J_PASSWORD", "password")` and `os.getenv("POSTGRES_PASSWORD", "postgres")` across all Python scripts and Jupyter notebooks.
- Updated Docker Compose YAML files to remove default fallbacks for passwords (e.g., `${NEO4J_PASSWORD:-password}` changed to `${NEO4J_PASSWORD}`).
- Updated `README.md` to remove mentions of default credentials and advise users to configure them via a `.env` file.
- Ensured consistency across all services (Neo4j, PostgreSQL, Metabase).

---
*PR created automatically by Jules for task [2583345106747644555](https://jules.google.com/task/2583345106747644555) started by @nichsedge*