### PR TITLE
🧪 [testing improvement] add unit tests for build_url in scrape_financial_ratio.py

### DIFF
--- a/python/tests/test_scrape_financial_ratio.py
+++ b/python/tests/test_scrape_financial_ratio.py
@@ -1,0 +1,40 @@
+import sys
+import os
+from unittest.mock import MagicMock
+
+# Mock curl_cffi before importing scrape_financial_ratio
+sys.modules["curl_cffi"] = MagicMock()
+
+# Add the parent directory to sys.path to import the module being tested
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scrape_financial_ratio import build_url, BASE_URL, QUERY_PARAMS
+from urllib.parse import parse_qs, urlparse
+
+def test_build_url_page_one():
+    """Test build_url with page_number=1"""
+    url = build_url(1)
+
+    # Check if BASE_URL is present
+    assert url.startswith(BASE_URL)
+
+    # Parse the URL to check query parameters
+    parsed_url = urlparse(url)
+    query_params = parse_qs(parsed_url.query, keep_blank_values=True)
+
+    # Check if all QUERY_PARAMS are present and correct
+    for key, value in QUERY_PARAMS.items():
+        assert query_params[key][0] == str(value)
+
+    # Check if pageNumber is correctly set
+    assert query_params['pageNumber'][0] == '1'
+
+def test_build_url_different_page():
+    """Test build_url with a different page_number"""
+    page_num = 5
+    url = build_url(page_num)
+
+    parsed_url = urlparse(url)
+    query_params = parse_qs(parsed_url.query, keep_blank_values=True)
+
+    assert query_params['pageNumber'][0] == str(page_num)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Added unit tests for the `build_url` function in `python/scrape_financial_ratio.py`.

📊 **Coverage:** What scenarios are now tested
- **Happy Path:** Verified that `build_url(1)` returns the correct base URL and all expected query parameters (from `QUERY_PARAMS` constant).
- **Dynamic Parameter:** Verified that `build_url(5)` correctly incorporates the `pageNumber` argument into the URL.
- **Robustness:** Tests use `urllib.parse` to robustly validate query parameters, handling URL encoding and parameter order.

✨ **Result:** The improvement in test coverage
- The `build_url` function is now fully covered by unit tests, ensuring that any changes to URL construction logic or base parameters are verified before deployment.
- Improved the project's overall testing infrastructure by adding a pattern for mocking external dependencies during import.

---
*PR created automatically by Jules for task [7733269728453232011](https://jules.google.com/task/7733269728453232011) started by @nichsedge*